### PR TITLE
remove extra 0x

### DIFF
--- a/scripts/bytecode-debugger.ts
+++ b/scripts/bytecode-debugger.ts
@@ -274,7 +274,7 @@ async function outputExecInfo(
   }
   console.log(callDataOutput);
   console.log(chalk.bold("CALL VALUE"));
-  console.log(`0x${callValue.toHexString()}`);
+  console.log(callValue.toHexString());
 
   console.log(bytecodeOutput);
   console.log(`${chalk.bold("Total Gas Used:")} ${execInfo.gasUsed}`);


### PR DESCRIPTION
This leads to invalid hex strings such as `0x0x0a`.

@lalexgap any reason to omit the '0x' from bytecode but not the other fields?