### PR TITLE
make output easier to read with a light terminal theme

### DIFF
--- a/scripts/bytecode-debugger.ts
+++ b/scripts/bytecode-debugger.ts
@@ -323,7 +323,7 @@ async function generateInstructionTable(
   for (let i = 0; i < numberOfLines && printCounter < code.length; i++) {
     const opCodeInfo = opCodeList.get(code[printCounter]);
     const currentColor =
-      printCounter === currentCounter ? chalk.inverse : chalk.reset;
+      printCounter === currentCounter ? chalk.whiteBright.bgBlue : chalk.reset;
     const valueColor =
       printCounter === currentCounter
         ? chalk.whiteBright.bgMagenta
@@ -386,7 +386,9 @@ function generateBytecodeOutput(
       const opCode = opCodeList.get(code[printCounter])!;
       let numToPush = opCode.name === "PUSH" ? opCode.code - 0x5f : 0;
 
-      byteCodeOutput += chalk.inverse(toPrettyByte(code[printCounter]));
+      byteCodeOutput += chalk.whiteBright.bgBlue(
+        toPrettyByte(code[printCounter])
+      );
 
       while (numToPush !== 0) {
         numToPush--;

--- a/scripts/bytecode-debugger.ts
+++ b/scripts/bytecode-debugger.ts
@@ -325,7 +325,9 @@ async function generateInstructionTable(
     const currentColor =
       printCounter === currentCounter ? chalk.inverse : chalk.reset;
     const valueColor =
-      printCounter === currentCounter ? chalk.bgMagenta : chalk.reset;
+      printCounter === currentCounter
+        ? chalk.whiteBright.bgMagenta
+        : chalk.reset;
 
     opCodeExecTable.push([
       currentColor(toPrettyHex(printCounter)),
@@ -390,7 +392,9 @@ function generateBytecodeOutput(
         numToPush--;
         printCounter++;
 
-        byteCodeOutput += chalk.bgMagenta(toPrettyByte(code[printCounter]));
+        byteCodeOutput += chalk.whiteBright.bgMagenta(
+          toPrettyByte(code[printCounter])
+        );
       }
     } else {
       byteCodeOutput += toPrettyByte(code[printCounter]);

--- a/scripts/bytecode-debugger.ts
+++ b/scripts/bytecode-debugger.ts
@@ -322,9 +322,9 @@ async function generateInstructionTable(
   for (let i = 0; i < numberOfLines && printCounter < code.length; i++) {
     const opCodeInfo = opCodeList.get(code[printCounter]);
     const currentColor =
-      printCounter === currentCounter ? chalk.bgBlue : chalk.white;
+      printCounter === currentCounter ? chalk.inverse : chalk.reset;
     const valueColor =
-      printCounter === currentCounter ? chalk.bgMagenta : chalk.white;
+      printCounter === currentCounter ? chalk.bgMagenta : chalk.reset;
 
     opCodeExecTable.push([
       currentColor(toPrettyHex(printCounter)),
@@ -383,7 +383,7 @@ function generateBytecodeOutput(
       const opCode = opCodeList.get(code[printCounter])!;
       let numToPush = opCode.name === "PUSH" ? opCode.code - 0x5f : 0;
 
-      byteCodeOutput += chalk.bgBlue(toPrettyByte(code[printCounter]));
+      byteCodeOutput += chalk.inverse(toPrettyByte(code[printCounter]));
 
       while (numToPush !== 0) {
         numToPush--;

--- a/scripts/bytecode-debugger.ts
+++ b/scripts/bytecode-debugger.ts
@@ -259,7 +259,7 @@ async function outputExecInfo(
   console.log(chalk.bold("FUNCTION"));
   // NOTE: format('sighhash') actually returns the function
   console.log(
-    `${functionToCall.format("sighash")}: 0x${chalk.bgGray(
+    `${functionToCall.format("sighash")}: 0x${chalk.inverse(
       utils.Interface.getSighash(functionToCall).slice(2)
     )}`
   );
@@ -267,7 +267,8 @@ async function outputExecInfo(
   let callDataOutput = "0x";
   for (let i = 0; i < callData.length; i++) {
     if (i < 4) {
-      callDataOutput = callDataOutput + chalk.bgGray(toPrettyByte(callData[i]));
+      callDataOutput =
+        callDataOutput + chalk.inverse(toPrettyByte(callData[i]));
     } else {
       callDataOutput = callDataOutput + toPrettyByte(callData[i]);
     }


### PR DESCRIPTION
Currently, the output looks good with a dark terminal theme, but not so much with a light one:

![Screenshot 2021-09-02 at 08 17 06](https://user-images.githubusercontent.com/1833419/131799956-5f8a01fa-5511-4679-a9ae-e2fdf2bb9ed3.png)

This change uses relative colours rather than absolute ones, or sets both the foreground and background colours, to make the output more readable in both light and dark terminals: 
![Screenshot 2021-09-02 at 08 33 31](https://user-images.githubusercontent.com/1833419/131801949-3359b8ea-a1d2-4c64-8f08-3fbf99047d17.png)





